### PR TITLE
ci(Renovate): 設定ファイルで警告が出ていた項目を削除した

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,8 +15,6 @@
   "prHourlyLimit": 0,
   // 作成できるPR/ブランチの上限（0で上限無し）
   "prConcurrentLimit": 0,
-  // Renovate のコミット上限（デフォルトは無制限）
-  "prCommitsPerRunLimit": 0,
   // アサイン
   "assignees": [
     "hytsnbr"


### PR DESCRIPTION
 ### 変更内容
- Renovateの設定でリポジトリ単位で設定すると無視され警告が出ていた `prCommitsPerRunLimit` を削除した