### PR TITLE
chore(husky): husky v9への更新に伴うコマンド・ファイル等の変更を行った

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@9.15.1",
   "scripts": {
-    "preinstall": "husky install",
+    "preinstall": "husky",
     "dev": "vite",
     "build": "vue-tsc && vite build",
     "preview": "pnpm build && vite preview",


### PR DESCRIPTION
参考リンク
- [Release v9.0.1 · typicode/husky](https://github.com/typicode/husky/releases/tag/v9.0.1)
- [【husky v9対応】yarn husky installで`install command is deprecated`になる](https://zenn.dev/otomoti_27/articles/692e1308ce849b)